### PR TITLE
Added ITER_SIZE parameter

### DIFF
--- a/wetectron/config/defaults.py
+++ b/wetectron/config/defaults.py
@@ -456,6 +456,10 @@ _C.SOLVER.CHECKPOINT_PERIOD = 2500
 # see 2 images per batch
 _C.SOLVER.IMS_PER_BATCH = 16
 
+# ITER_SIZE allows for the faking of batches
+# Effective batch size = ITER_SIZE * IMS_PER_BATCH
+_C.SOLVER.IMS_PER_BATCH
+
 # ---------------------------------------------------------------------------- #
 # Solver CDB
 # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
I've added the code to allow for a `SOLVER.ITER_SIZE` parameter similar to Caffe. Changing the `ITER_SIZE` results in an effective batch size of `IMS_PER_BATCH * ITER_SIZE`. I've set it up to only step the scheduler every `ITER_SIZE` steps, and automatically update `MAX_ITERS` to account for the changes. As a result the `STEPS` don't need to be updated when using it. It produces a warning when this is in use to prevent accidental issues.

e.g. 
```
SOLVER:
  IMS_PER_BATCH: 8
  WARMUP_ITERS: 200
  STEPS: (20000, 26700)
  MAX_ITER: 30000
```
is equivalent to
```
SOLVER:
  IMS_PER_BATCH: 1
  ITER_SIZE: 8
  WARMUP_ITERS: 200
  STEPS: (20000, 26700)
  MAX_ITER: 30000
```

This is a pretty slow way to train, and may not yield identical results, but they're usually pretty close. It defaults to 1 so that nothing gets broken. It is super helpful for those of us who can't easily access 8 GPUs for experiments, as well as allowing for arbitrarily large batch sizes if you have the time and can fit at least 1 pass in memory (e.g. for batch size 64 you could do `IMS_PER_BATCH: 8`, `ITER_SIZE: 8`).

Unfortunately, it's non-trivial to make it work with CDB due to the structure of the training loop so I've just made it incompatible with CDB rather than introduce a broken implementation.